### PR TITLE
Make non-ASCII symbols in Sequence features readable

### DIFF
--- a/run.py
+++ b/run.py
@@ -322,7 +322,7 @@ if start:
                     ):
                         df_item[k] = v
                     else:
-                        out = json.dumps(v, indent=2, sort_keys=True)
+                        out = json.dumps(v, indent=2, sort_keys=True, ensure_ascii=False)
                         df_item[k] = out
                 df.append(df_item)
             df2 = df


### PR DESCRIPTION
Currently, due to the default behavior of `json.dumps`, unicode (i.e. all non-ASCII) symbols in `Sequence` dataset features are escaped, and thus made unreadable. See the image below (example from the RuCoS task in the [Russian SuperGLUE](https://huggingface.co/datasets/viewer/?dataset=russian_super_glue) benchmark).

![image](https://user-images.githubusercontent.com/44175589/127687967-5cd8dc83-15ba-4f82-88dd-9cf8667c7234.png)

This doesn't appear to be intentional, so I suggest a small fix inspired by @abdulrahimq's idea in #6.